### PR TITLE
Fix the Finder in the scan command: follow symlinks; allow whitespace chars

### DIFF
--- a/src/Translation.php
+++ b/src/Translation.php
@@ -48,11 +48,13 @@ class Translation
             '(?<!->)' . // Must not start with ->
             '(' . implode('|', $functions) . ')' . // Must start with one of the functions
             "\(" . // Match opening parentheses
+            "\s*" . // Allow whitespace chars after the opening parenthese
             "[\'\"]" . // Match " or '
             '(' . // Start a new group to match:
             '.+' . // Must start with group
             ')' . // Close group
             "[\'\"]" . // Closing quote
+            "\s*" . // Allow whitespace chars before the closing parenthese
             "[\),]"  // Close parentheses or new parameter
         ;
 

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -33,7 +33,9 @@ class Translation
         $finder->in(base_path())
             ->exclude(config('translation.excluded_directories'))
             ->name(config('translation.extensions'))
+            ->followLinks()
             ->files();
+
         /*
          * This pattern is derived from Barryvdh\TranslationManager by Barry vd. Heuvel <barryvdh@gmail.com>
          *


### PR DESCRIPTION
This PR:

- Enables following symbolic links
  So files in symlinked directories are scanned as well
- Allows whitespace chars after the opening parenthese as well as before the closing one
  So translation strings used in methods which are laid out like this are found as well:
  ```php
  trans(
      'group.message',
      ['fdsfd']
  );
  ```
Fixes #10 