### PR TITLE
Feature: option to skip trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ php artisan translation:upload {--translations=all : Upload translations for lan
 
 To download languages from poeditor run this command:
 ```bash
-php artisan translation:download
+php artisan translation:download {--skip-trimming : Whether translation trimming should be skipped}
 ``` 
 
 **Create JS language files**

--- a/src/Commands/Download.php
+++ b/src/Commands/Download.php
@@ -8,7 +8,8 @@ use Vemcogroup\Translation\Translation;
 
 class Download extends Command
 {
-    protected $signature = 'translation:download';
+    protected $signature = 'translation:download
+                            {--skip-trimming : Whether translation trimming should be skipped}';
     protected $description = 'Download all languages from POEditor';
 
     public function handle(): void
@@ -16,7 +17,7 @@ class Download extends Command
         try {
             $this->info('⬇️  Preparing to download languages');
 
-            $languages = app(Translation::class)->download();
+            $languages = app(Translation::class)->download($this->option('skip-trimming'));
 
             $this->info('⬇️  Finished downloading languages: ' . $languages->implode(', '));
         } catch (Exception $e) {

--- a/src/Translation.php
+++ b/src/Translation.php
@@ -20,6 +20,7 @@ class Translation
     protected $projectId;
     protected $baseLanguage;
     protected $baseFilename;
+    protected $skipTrimming;
 
     public function __construct()
     {
@@ -123,7 +124,10 @@ class Translation
         }
 
         $languages = collect($response['result']['languages']);
-        $languages->each(function ($language) use ($skipTrimming) {
+
+        $this->skipTrimming = $skipTrimming;
+
+        $languages->each(function ($language) {
             $response = $this->query('https://api.poeditor.com/v2/projects/export', [
                 'form_params' => [
                     'api_token' => $this->apiKey,
@@ -134,8 +138,8 @@ class Translation
             ], 'POST');
 
             $content = collect($this->query($response['result']['url']))
-                ->mapWithKeys(function ($entry, $key) use ($skipTrimming) {
-                    if ($skipTrimming) {
+                ->mapWithKeys(function ($entry, $key) {
+                    if ($this->skipTrimming) {
                         return is_array($entry) ? [array_key_first($entry) => array_pop($entry)] : [$key => $entry];
                     }
                     return is_array($entry) ? [trim(array_key_first($entry)) => array_pop($entry)] : [$key => trim($entry)];


### PR DESCRIPTION
This was discussed in #11 but a solution was never implemented. Opted to add it as a switch option to the download command, so it is nicely backwards compatible and no config files need to be updated. I didn't add the option to skip trimming when using download as option to create-js. If people need that can do it in multiple steps (first download, then create-js).